### PR TITLE
[SUGGESTION] Accept only images supported by the sonolus app

### DIFF
--- a/src/components/ui/MyImageInput.vue
+++ b/src/components/ui/MyImageInput.vue
@@ -108,7 +108,7 @@ function clear() {
             ref="el"
             class="hidden"
             type="file"
-            accept="image/*"
+            accept="image/png, image/jpeg"
             @input="onFileInput()"
         />
     </div>


### PR DESCRIPTION
Currently, studio accepts every images includes sonolus doesn't support. (ex. animated gif)
I think it should only accepts images that sonolus supporting.
I don't know what extensions does sonolus actually supporting.
This is just suggestion and will need more change.