### PR TITLE
optimize particle data and deduplicate skin sprites

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,5 +9,6 @@
     "types": ["vite/client", "vite-svg-loader"],
 
     "noUncheckedIndexedAccess": true,
+    "downlevelIteration": true,
   }
 }


### PR DESCRIPTION
**Particles**
- Implemented `pruneNode` to remove animation properties where values are zero, reducing payload size.
- Ensured `c:0` is preserved when all other values are pruned.

**Skins**
- Improved deduplication logic by using content hashing (`packRaw`) instead of texture paths.
- Sprites with identical content and padding now share the same texture atlas region, optimizing texture memory.

**Config**
- Enabled `downlevelIteration` in `tsconfig.app.json` to resolve iterator type errors during the build process.